### PR TITLE
fix "Identifier 'process' has already been declared", add "set" function, parsers and send buffer

### DIFF
--- a/serial_events.js
+++ b/serial_events.js
@@ -15,6 +15,9 @@ module.exports = {
     write_success : "serial-write-success",
     write_failed : "serial-write-failed",
 
+    set_success : "serial-set-success",
+    set_failed : "serial-set-failed",
+
     //Public Serial Port Events
     data : "serial-data",
     open : "serial-open",

--- a/serial_master.js
+++ b/serial_master.js
@@ -28,6 +28,9 @@ class SerialInterface extends events.EventEmitter {
         });
 
         $.reporter.on(SERIAL_EVENTS.data,(data)=>{
+            console.log("data");
+            if(data.type=="Buffer")
+              data = new Buffer(data.data);
             $.emit("data",data);
         });
         $.reporter.on(SERIAL_EVENTS.open,()=>{

--- a/serial_master.js
+++ b/serial_master.js
@@ -75,6 +75,21 @@ class SerialInterface extends events.EventEmitter {
         });
     }
 
+    set(options, callback){
+        let $ = this;
+        serial_worker.send({func:"set",param:options});
+        $.reporter.once(SERIAL_EVENTS.set_success,(result)=>{
+            if(callback){
+                callback(null, result);
+            }
+        });
+        $.reporter.once(SERIAL_EVENTS.set_failed,(err)=>{
+            if(callback){
+                callback(err);
+            }
+        });
+    }
+
     write(buffer, callback){
         let $ = this;
         serial_worker.send({func:'write',param:buffer});

--- a/serial_master.js
+++ b/serial_master.js
@@ -2,7 +2,7 @@
 
 const events = require('events');
 const cp = require('child_process');
-const process = require("process");
+const processModule = require("process");
 const SERIAL_EVENTS = require(__dirname + '/serial_events.js');
 
 
@@ -120,7 +120,7 @@ class SerialInterface extends events.EventEmitter {
 
 
 
-process.on('exit', function() {
+processModule.on('exit', function() {
     serial_worker.kill();
 });
 

--- a/serial_worker.js
+++ b/serial_worker.js
@@ -1,12 +1,12 @@
 'use strict'
 const serial = require('serialport');
 const serialport = serial.SerialPort;
-const process = require('process');
+const processModule = require('process');
 const SERIAL_EVENTS = require(__dirname + '/serial_events.js');
 
 var port = null;
 
-process.on('message',function(msg){
+processModule.on('message',function(msg){
     let func_name = msg.func;
     let func_param = msg.param;
     //console.log(func_param);
@@ -24,7 +24,7 @@ process.on('message',function(msg){
                     eventType : SERIAL_EVENTS.data,
                     body : data
                 };
-                process.send(res);
+                processModule.send(res);
             });
 
             //This event sometime fired sometimes not fired
@@ -37,7 +37,7 @@ process.on('message',function(msg){
                     body : undefined
                 };
                 console.log("SENDING GGG");
-                process.send(res);
+                processModule.send(res);
             });
             */
             port.on('close',()=>{
@@ -45,7 +45,7 @@ process.on('message',function(msg){
                     eventType : SERIAL_EVENTS.close,
                     body : undefined
                 };
-                process.send(res);
+                processModule.send(res);
             });
 
             if(immediate !== false){
@@ -67,7 +67,7 @@ process.on('message',function(msg){
                         body : ports
                     };
                 }
-                process.send(list_res);
+                processModule.send(list_res);
             });
             break;
 
@@ -76,7 +76,7 @@ process.on('message',function(msg){
                 eventType:SERIAL_EVENTS.is_open,
                 body : port.isOpen()
             }
-            process.send(is_res);
+            processModule.send(is_res);
             break;
 
         default:
@@ -91,13 +91,13 @@ process.on('message',function(msg){
 
                     //fix open event not fired by ommiting original open event
                     if(func_name === "open"){
-                        process.send({
+                        processModule.send({
                             eventType : SERIAL_EVENTS.open,
                             body : undefined
                         });
                     }
                 }
-                process.send(res);
+                processModule.send(res);
             }
             if(func_param){
                 port[func_name](func_param,callbackfunc);

--- a/serialport.js
+++ b/serialport.js
@@ -1,7 +1,9 @@
 
 const SerialInterface = require( __dirname + '/serial_master.js')
+const SerialPort = require( 'serialport')
 
 module.exports={
     list : SerialInterface.list,
+    parsers : SerialPort.parsers,
     SerialPort : SerialInterface
 }


### PR DESCRIPTION
Everything work now but I think the parsers feature doesn't work. Have to send parsers option to the workers I think.
